### PR TITLE
use aya-log info! macro

### DIFF
--- a/tcbpftest-ebpf/Cargo.toml
+++ b/tcbpftest-ebpf/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 
 [dependencies]
 aya-bpf = { git = "http://github.com/aya-rs/aya", branch = "main" }
-memoffset = "0.6"
+aya-log-ebpf = { git = "https://github.com/aya-rs/aya-log", branch = "main" }
+memoffset = "0.6.1"
 tcbpftest-common = { path = "../tcbpftest-common" }
 
 [[bin]]

--- a/tcbpftest-ebpf/src/main.rs
+++ b/tcbpftest-ebpf/src/main.rs
@@ -105,6 +105,7 @@ unsafe fn try_tcbpftest(ctx: TcContext) -> Result<i32, i64> {
     unsafe {
         EVENTS.output(&ctx, &log_entry, 0);
     }
+    info!(&ctx, "packet:");
     Ok(0)
 }
 

--- a/tcbpftest-ebpf/src/main.rs
+++ b/tcbpftest-ebpf/src/main.rs
@@ -9,6 +9,7 @@ use aya_bpf::{
 };
 use aya_bpf::bindings:: __sk_buff;
 use aya_bpf::helpers::bpf_skb_pull_data;
+use aya_log_ebpf::info;
 use core::mem;
 use memoffset::offset_of;
 

--- a/tcbpftest/src/main.rs
+++ b/tcbpftest/src/main.rs
@@ -66,6 +66,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 for buf in buffers.iter_mut().take(events.read) {
                     let ptr = buf.as_ptr() as *const PacketLog;
                     let data = unsafe { ptr.read_unaligned() };
+                    /*
                     println!(
                         "LOG: LEN {}, CTX_LEN {}, UDP_LEN {}, SRC_IP {}, DEST_IP {}, ETH_PROTO 0x{:X}, ETH_PROTO2 0x{:X}, IP_PROTO {}, REMOTE_PORT {}, REMOTE_PORT2 {}, LOCAL_PORT {}, LOCAL_PORT2 {}",
                         data.len,
@@ -81,6 +82,7 @@ async fn main() -> Result<(), anyhow::Error> {
                         data.local_port,
                         data.local_port2,
                     );
+                    */
                 }
             }
         });


### PR DESCRIPTION
An attempt to use the `info!` macro to display the information - currently resulting in the verifier error:
```
20:53:21 [DEBUG] (1) aya::obj::relocation: [/home/dsavints/.cargo/git/checkouts/aya-c55fbc69175ac116/6f301ac/aya/src/obj/relocation.rs:363] finished relocating program tcbpftest function tcbpftest
Error: the BPF_PROG_LOAD syscall failed. Verifier output: func#0 @0
func#1 @353
func#2 @364
func#3 @365
last insn is not an exit or jmp
verification time 14 usec
stack depth 0+0+0+0
processed 0 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0


Caused by:
    Invalid argument (os error 22)
```