### PR TITLE
renaming aya-gen to aya-tool

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aya-gen = { git = "https://github.com/aya-rs/aya", branch = "main" }
+aya-tool = { git = "https://github.com/aya-rs/aya", branch = "main" }
 structopt = { version = "0.3.26", default-features = false }
 anyhow = "1.0.58"

--- a/xtask/src/codegen.rs
+++ b/xtask/src/codegen.rs
@@ -1,10 +1,10 @@
-use aya_gen::generate::InputFile;
+use aya_tool::generate::InputFile;
 use std::{fs::File, io::Write, path::PathBuf};
 
 pub fn generate() -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("tcbpftest-ebpf/src");
     let names: Vec<&str> = vec!["ethhdr", "iphdr", "tcphdr", "udphdr"];
-    let bindings = aya_gen::generate(
+    let bindings = aya_tool::generate(
         InputFile::Btf(PathBuf::from("/sys/kernel/btf/vmlinux")),
         &names,
         &[],


### PR DESCRIPTION
`aya-gen` has been renamed to `aya-tool` upstream: https://github.com/aya-rs/aya/pull/374