### PR TITLE
allow to build/run both debug (default) and release builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,23 +20,33 @@ cargo install bpf-linker
 ```
 
 # Build and Run
+You can add the `--release` flag to perform a release build.
 ```
 git clone https://github.com/dmitris/tcbpftest
 cd tcbpftest
-```
+
 # build eBPF object file
-```
-cargo xtask build-ebpf
-```
+
+cargo xtask build-ebpf [--release]
+
 # build the user-space program
-```
-cargo build --release
+
+cargo build [--release]
 ```
 
-NB: for a debug build: `cargo xtask build-ebpf --debug && cargo build`.
+To run the program:
+```
+# debug build
+sudo ./target/debug/tcbpftest
 
-Load into the kernel and attach the eBPF object file to the `tc` hook,
-then run the user-space program reading data from the maps and printing to stdout:
+# release build
+sudo ./target/release/tcbpftest
+```
+
+You can also use `cargo xtask run [--release]` to build and run the program with one command.
+
+The `tcbpftest` executable loads into the kernel the eBPF object file and attaches it to the `tc` hook,
+then runs the user-space program reading data from the maps and printing to stdout:
 ```
 sudo target/release/tcbpftest
 
@@ -47,6 +57,8 @@ LOG: LEN 52, CTX_LEN 66, SRC_IP 140.82.113.26, DEST_IP 192.168.178.36, ETH_PROTO
 ```
 
 # Cross-compilation
+NB: the `llvm-sys` crate appears to be currently broken on Mac: [issue](https://gitlab.com/taricorp/llvm-sys.rs/-/issues/39).
+
 The example program can be cross-compiled on an Intel Mac for Linux:
 ```
 rustup target add x86_64-unknown-linux-musl
@@ -54,8 +66,8 @@ brew install FiloSottile/musl-cross/musl-cross
 brew install llvm
 # adjust the path for LLVM installation as needed - if installed with brew on Mac,
 # it is normally /usr/local/opt/llvm - see $(brew --prefix llvm).
-LLVM_SYS_140_PREFIX=/opt/local cargo install bpf-linker --no-default-features --features system-llvm --force
-cargo xtask build-ebpf
+$ LLVM_SYS_150_PREFIX=/opt/local cargo install bpf-linker --no-default-features --features system-llvm --force
+$ cargo xtask build-ebpf
 # '-C link-arg=-s' and '--release' flags are optional (to produce a smaller executable file)
 RUSTFLAGS="-Clinker=x86_64-linux-musl-ld -C link-arg=-s" cargo build --release --target=x86_64-unknown-linux-musl
 

--- a/tcbpftest-ebpf/Cargo.toml
+++ b/tcbpftest-ebpf/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 aya-bpf = { git = "http://github.com/aya-rs/aya", branch = "main" }
-memoffset = "0.6.1"
+memoffset = "0.6"
 tcbpftest-common = { path = "../tcbpftest-common" }
 
 [[bin]]
@@ -13,13 +13,20 @@ name = "tcbpftest"
 path = "src/main.rs"
 
 [profile.dev]
-panic = "abort"
-debug = 1
-opt-level = 2
+opt-level = 3
+debug = false
+debug-assertions = false
 overflow-checks = false
+lto = true
+panic = "abort"
+incremental = false
+codegen-units = 1
+rpath = false
 
 [profile.release]
+lto = true
 panic = "abort"
+codegen-units = 1
 
 [workspace]
 members = []

--- a/tcbpftest/Cargo.toml
+++ b/tcbpftest/Cargo.toml
@@ -8,11 +8,11 @@ publish = false
 aya = { version = ">=0.11", features=["async_tokio"] }
 tcbpftest-common = { path = "../tcbpftest-common", features=["userspace"] }
 anyhow = "1.0.42"
-bytes = "1.1"
+bytes = "1"
+clap = { version = "3"}
 ctrlc = "3.2"
 log = "0.4"
 simplelog = "0.12"
-structopt = { version = "0.3"}
 tokio = { version = "1.18", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
 
 [[bin]]

--- a/tcbpftest/Cargo.toml
+++ b/tcbpftest/Cargo.toml
@@ -5,16 +5,15 @@ edition = "2021"
 publish = false
 
 [dependencies]
-aya = { git = "https://github.com/aya-rs/aya", branch="main", features=["async_tokio"] }
+aya = { version = ">=0.11", features=["async_tokio"] }
 tcbpftest-common = { path = "../tcbpftest-common", features=["userspace"] }
 anyhow = "1.0.42"
 bytes = "1.1"
 ctrlc = "3.2"
-
-structopt = { version = "0.3"}
-tokio = { version = "1.5.0", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
-simplelog = "0.11"
 log = "0.4"
+simplelog = "0.12"
+structopt = { version = "0.3"}
+tokio = { version = "1.18", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
 
 [[bin]]
 name = "tcbpftest"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 aya-tool = { git = "https://github.com/aya-rs/aya", branch = "main" }
-structopt = { version = "0.3.26", default-features = false }
-anyhow = "1.0.58"
+clap = { version = "3", features = ["derive"] }
+anyhow = "1"

--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -40,10 +40,10 @@ pub struct Options {
     pub release: bool,
 }
 
-pub fn build(opts: Options) -> Result<(), anyhow::Error> {
+pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("tcbpftest-ebpf");
     let target = format!("--target={}", opts.target);
-    let args = vec![
+    let mut args = vec![
         "+nightly",
         "build",
         "--verbose",

--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-use structopt::StructOpt;
+use clap::Parser;
 
 #[derive(Debug, Copy, Clone)]
 pub enum Architecture {
@@ -52,11 +52,14 @@ pub fn build(opts: Options) -> Result<(), anyhow::Error> {
         "--profile",
         opts.profile.as_str(),
     ];
+    if opts.release {
+        args.push("--release")
+    }
     let status = Command::new("cargo")
         .current_dir(&dir)
         .args(&args)
         .status()
-        .expect("failed to build bpf examples");
+        .expect("failed to build bpf program");
     assert!(status.success());
     Ok(())
 }

--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -30,13 +30,14 @@ impl std::fmt::Display for Architecture {
     }
 }
 
-#[derive(StructOpt)]
+#[derive(Debug, Parser)]
 pub struct Options {
-    #[structopt(default_value = "bpfel-unknown-none", long)]
-    target: Architecture,
-    /// Build profile for eBPF programs
-    #[structopt(default_value = "release", long)]
-    pub profile: String,
+    /// Set the endianness of the BPF target
+    #[clap(default_value = "bpfel-unknown-none", long)]
+    pub target: Architecture,
+    /// Build the release target
+    #[clap(long)]
+    pub release: bool,
 }
 
 pub fn build(opts: Options) -> Result<(), anyhow::Error> {
@@ -49,8 +50,6 @@ pub fn build(opts: Options) -> Result<(), anyhow::Error> {
         target.as_str(),
         "-Z",
         "build-std=core",
-        "--profile",
-        opts.profile.as_str(),
     ];
     if opts.release {
         args.push("--release")

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,5 +1,6 @@
 mod build_ebpf;
 mod codegen;
+mod run;
 
 use std::process::exit;
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,25 +3,28 @@ mod codegen;
 
 use std::process::exit;
 
-use structopt::StructOpt;
-#[derive(StructOpt)]
+use clap::Parser;
+
+#[derive(Debug, Parser)]
 pub struct Options {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     command: Command,
 }
 
-#[derive(StructOpt)]
+#[derive(Debug, Parser)]
 enum Command {
     BuildEbpf(build_ebpf::Options),
+    Run(run::Options),
     Codegen,
 }
 
 fn main() {
-    let opts = Options::from_args();
+    let opts = Options::parse();
 
     use Command::*;
     let ret = match opts.command {
         BuildEbpf(opts) => build_ebpf::build(opts),
+        Run(opts) => run::run(opts),
         Codegen => codegen::generate(),
     };
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
 
     use Command::*;
     let ret = match opts.command {
-        BuildEbpf(opts) => build_ebpf::build(opts),
+        BuildEbpf(opts) => build_ebpf::build_ebpf(opts),
         Run(opts) => run::run(opts),
         Codegen => codegen::generate(),
     };

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -1,0 +1,67 @@
+use std::{os::unix::process::CommandExt, process::Command};
+
+use anyhow::Context as _;
+use clap::Parser;
+
+use crate::build_ebpf::{build_ebpf, Architecture, Options as BuildOptions};
+
+#[derive(Debug, Parser)]
+pub struct Options {
+    /// Set the endianness of the BPF target
+    #[clap(default_value = "bpfel-unknown-none", long)]
+    pub bpf_target: Architecture,
+    /// Build and run the release target
+    #[clap(long)]
+    pub release: bool,
+    /// The command used to wrap your application
+    #[clap(short, long, default_value = "sudo -E")]
+    pub runner: String,
+    /// Arguments to pass to your application
+    #[clap(name = "args", last = true)]
+    pub run_args: Vec<String>,
+}
+
+/// Build the project
+fn build(opts: &Options) -> Result<(), anyhow::Error> {
+    let mut args = vec!["build"];
+    if opts.release {
+        args.push("--release")
+    }
+    let status = Command::new("cargo")
+        .args(&args)
+        .status()
+        .expect("failed to build userspace");
+    assert!(status.success());
+    Ok(())
+}
+
+/// Build and run the project
+pub fn run(opts: Options) -> Result<(), anyhow::Error> {
+    // build our ebpf program followed by our application
+    build_ebpf(BuildOptions {
+        target: opts.bpf_target,
+        release: opts.release,
+    })
+    .context("Error while building eBPF program")?;
+    build(&opts).context("Error while building userspace application")?;
+
+    // profile we are building (release or debug)
+    let profile = if opts.release { "release" } else { "debug" };
+    let bin_path = format!("target/{}/tc-egress", profile);
+
+    // arguments to pass to the application
+    let mut run_args: Vec<_> = opts.run_args.iter().map(String::as_str).collect();
+
+    // configure args
+    let mut args: Vec<_> = opts.runner.trim().split_terminator(' ').collect();
+    args.push(bin_path.as_str());
+    args.append(&mut run_args);
+
+    // spawn the command
+    let err = Command::new(args.get(0).expect("No first argument"))
+        .args(args.iter().skip(1))
+        .exec();
+
+    // we shouldn't get here unless the command failed to spawn
+    Err(anyhow::Error::from(err).context(format!("Failed to run `{}`", args.join(" "))))
+}

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -47,7 +47,7 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
 
     // profile we are building (release or debug)
     let profile = if opts.release { "release" } else { "debug" };
-    let bin_path = format!("target/{}/tc-egress", profile);
+    let bin_path = format!("target/{}/tcbpftest", profile);
 
     // arguments to pass to the application
     let mut run_args: Vec<_> = opts.run_args.iter().map(String::as_str).collect();


### PR DESCRIPTION
PR allows to build and run both debug (default) and release builds (the latter with the `--release` flag).
It mostly copies settings and code from the [tc-egress](https://github.com/aya-rs/book/tree/main/examples/tc-egress) example.