### PR TITLE
refactor for the new API

### DIFF
--- a/tcbpftest-ebpf/src/main.rs
+++ b/tcbpftest-ebpf/src/main.rs
@@ -26,14 +26,14 @@ use tcbpftest_common::PacketLog;
 #[allow(dead_code)]
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
-    unreachable!()
+    unsafe { core::hint::unreachable_unchecked() }
 }
 
-#[map(name = "EVENTS")]
+#[map]
 static mut EVENTS: PerfEventArray<PacketLog> =
     PerfEventArray::<PacketLog>::with_max_entries(1024, 0);
 
-#[classifier(name = "tcbpftest")]
+#[classifier]
 pub fn tcbpftest(ctx: TcContext) -> i32 {
     match unsafe { try_tcbpftest(ctx) } {
         Ok(ret) => ret,

--- a/tcbpftest/src/main.rs
+++ b/tcbpftest/src/main.rs
@@ -57,11 +57,7 @@ async fn main() -> Result<(), anyhow::Error> {
             program.prog_type()
         );
     }
-    let p = match bpf.program_mut("classifier") {
-        Some(v) => v,
-        None => panic!("bpf.program_mut('classifier') returned 'None'")
-    };
-    let program: &mut SchedClassifier = p.try_into()?;
+    let program: &mut SchedClassifier = bpf.program_mut("classifier").unwrap().try_into()?;
     program.load()?;
     // program.attach(&args.iface, TcAttachType::Egress)?;
     program.attach(&args.iface, TcAttachType::Ingress)?;


### PR DESCRIPTION
aya has changed how the name are specified - https://github.com/aya-rs/aya/pull/413#issue-1406508419
This change makes the test program to compile and run.

On a Mac:
```bash
$ cargo xtask build-ebpf --release \
    && RUSTFLAGS="-Clinker=x86_64-linux-musl-ld -C link-arg=-s" cargo build --release --target=x86_64-unknown-linux-musl \
    && scp target/x86_64-unknown-linux-musl/release/tcbpftest <linuxVM>:/tmp
```

On Linux:
```bash
$ sudo /tmp/tcbpftest
11:57:05 [DEBUG] (1) aya::bpf: [/Users/dmitris/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aya-0.11.0/src/bpf.rs:106] [FEAT PROBE] BPF program name support: true
[...]
[INFO] found program `classifier` of type `BPF_PROG_TYPE_SCHED_CLS`
11:57:05 [INFO] tcbpftest: [tcbpftest/src/main.rs:106] Waiting for Ctrl-C...

LOG: LEN 212, CTX_LEN 226, UDP_LEN 192, SRC_IP 69.147.127.86, DEST_IP 10.93.77.0, ETH_PROTO 0x800, IP_PROTO 17, SRC_PORT 53, DEST_PORT 45605
LOG: LEN 134, CTX_LEN 148, UDP_LEN 114, SRC_IP 69.147.127.86, DEST_IP 10.93.77.0, ETH_PROTO 0x800, IP_PROTO 17, SRC_PORT 53, DEST_PORT 45918
^C11:57:13 [INFO] tcbpftest: [tcbpftest/src/main.rs:108] Exiting...
```