### PR TITLE
fix for the new Aya API

### DIFF
--- a/tcbpftest-ebpf/src/main.rs
+++ b/tcbpftest-ebpf/src/main.rs
@@ -34,7 +34,7 @@ static mut EVENTS: PerfEventArray<PacketLog> =
     PerfEventArray::<PacketLog>::with_max_entries(1024, 0);
 
 #[classifier]
-pub fn foobartest(ctx: TcContext) -> i32 {
+pub fn tcbpftest(ctx: TcContext) -> i32 {
     match unsafe { try_tcbpftest(ctx) } {
         Ok(ret) => ret,
         Err(_) => 123,

--- a/tcbpftest-ebpf/src/main.rs
+++ b/tcbpftest-ebpf/src/main.rs
@@ -34,7 +34,7 @@ static mut EVENTS: PerfEventArray<PacketLog> =
     PerfEventArray::<PacketLog>::with_max_entries(1024, 0);
 
 #[classifier]
-pub fn tcbpftest(ctx: TcContext) -> i32 {
+pub fn foobartest(ctx: TcContext) -> i32 {
     match unsafe { try_tcbpftest(ctx) } {
         Ok(ret) => ret,
         Err(_) => 123,

--- a/tcbpftest/Cargo.toml
+++ b/tcbpftest/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-aya = { version = ">=0.11", features = ["async_tokio"] }
+aya = { git = "https://github.com/aya-rs/aya", features = ["async_tokio"] }
+aya-log = { git = "https://github.com/aya-rs/aya" }
 tcbpftest-common = { path = "../tcbpftest-common", features = ["user"] }
 anyhow = "1"
 bytes = "1"

--- a/tcbpftest/src/main.rs
+++ b/tcbpftest/src/main.rs
@@ -58,7 +58,6 @@ async fn main() -> Result<(), anyhow::Error> {
         );
     }
     let program: &mut SchedClassifier = bpf.program_mut("foobartest").unwrap().try_into()?;
-    program.load()?;
     // program.attach(&args.iface, TcAttachType::Egress)?;
     program.attach(&args.iface, TcAttachType::Ingress)?;
 

--- a/tcbpftest/src/main.rs
+++ b/tcbpftest/src/main.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // error adding clsact to the interface if it is already added is harmless
     // the full cleanup can be done with 'sudo tc qdisc del dev eth0 clsact'.
     let _ = tc::qdisc_add_clsact(&args.iface);
-    // this is just for information and debugging - show the found programs.
+    // this is just for information and debugging - show all the found programs.
     for (name, program) in bpf.programs() {
         println!(
             "[INFO] found program `{}` of type `{:?}`",
@@ -62,11 +62,11 @@ async fn main() -> Result<(), anyhow::Error> {
             program.prog_type()
         );
     }
-    let program: &mut SchedClassifier = bpf.program_mut("foobartest").unwrap().try_into()?;
+    let program: &mut SchedClassifier = bpf.program_mut("tcbpftest").unwrap().try_into()?;
     program.load()?;
     program.attach(&args.iface, TcAttachType::Ingress)?;
 
-    let mut perf_array = AsyncPerfEventArray::try_from(bpf.map_mut("EVENTS").unwrap())?;
+    let mut perf_array = AsyncPerfEventArray::try_from(bpf.take_map("EVENTS").unwrap())?;
 
     let cpus = online_cpus()?;
     let num_cpus = cpus.len();

--- a/tcbpftest/src/main.rs
+++ b/tcbpftest/src/main.rs
@@ -8,7 +8,7 @@ use aya::{
 use aya_log::BpfLogger;
 use bytes::BytesMut;
 use clap::Parser;
-use log::info;
+use log::{info, warn};
 use simplelog::{ColorChoice, ConfigBuilder, LevelFilter, TermLogger, TerminalMode};
 use std::net::Ipv4Addr;
 use tokio::{signal, task};
@@ -47,6 +47,10 @@ async fn main() -> Result<(), anyhow::Error> {
     let mut bpf = Bpf::load(include_bytes_aligned!(
         "../../target/bpfel-unknown-none/release/tcbpftest"
     ))?;
+    if let Err(e) = BpfLogger::init(&mut bpf) {
+        // This can happen if you remove all log statements from your eBPF program.
+        warn!("failed to initialize eBPF logger: {}", e);
+    }
     // error adding clsact to the interface if it is already added is harmless
     // the full cleanup can be done with 'sudo tc qdisc del dev eth0 clsact'.
     let _ = tc::qdisc_add_clsact(&args.iface);

--- a/tcbpftest/src/main.rs
+++ b/tcbpftest/src/main.rs
@@ -5,6 +5,7 @@ use aya::{
     util::online_cpus,
     Bpf,
 };
+use aya_log::BpfLogger;
 use bytes::BytesMut;
 use clap::Parser;
 use log::info;

--- a/tcbpftest/src/main.rs
+++ b/tcbpftest/src/main.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<(), anyhow::Error> {
         );
     }
     let program: &mut SchedClassifier = bpf.program_mut("foobartest").unwrap().try_into()?;
-    // program.attach(&args.iface, TcAttachType::Egress)?;
+    program.load()?;
     program.attach(&args.iface, TcAttachType::Ingress)?;
 
     let mut perf_array = AsyncPerfEventArray::try_from(bpf.map_mut("EVENTS").unwrap())?;

--- a/tcbpftest/src/main.rs
+++ b/tcbpftest/src/main.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), anyhow::Error> {
             program.prog_type()
         );
     }
-    let program: &mut SchedClassifier = bpf.program_mut("classifier").unwrap().try_into()?;
+    let program: &mut SchedClassifier = bpf.program_mut("foobartest").unwrap().try_into()?;
     program.load()?;
     // program.attach(&args.iface, TcAttachType::Egress)?;
     program.attach(&args.iface, TcAttachType::Ingress)?;


### PR DESCRIPTION
Continues the fixes in #22.  Need to use the `aya = { git = "https://github.com/aya-rs/aya", features = ["async_tokio"] }` git dependency for now (until the next aya release).
The `bpf.take_mup` is similar to https://github.com/aya-rs/book/pull/131.